### PR TITLE
feat: 유저 프로필 수정 로직 변경

### DIFF
--- a/backend/account/permissions.py
+++ b/backend/account/permissions.py
@@ -3,11 +3,13 @@ from rest_framework.exceptions import ValidationError
 
 class IsOwnerOreadOnly(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
-        if request.method in permissions.SAFE_METHODS:
-            return True
-        if (hasattr(request.user, 'student')):
-            return obj == request.user.student
-        elif (hasattr(request.user, 'teacher')):
-            return obj == request.user.teacher
-        else:
-            raise ValidationError("유효하지 않은 사용자 유형입니다.")
+        if request.user.is_authenticated:
+            if request.method in permissions.SAFE_METHODS:
+                return True
+            if (hasattr(request.user, 'student')):
+                return obj == request.user.student
+            elif (hasattr(request.user, 'teacher')):
+                return obj == request.user.teacher
+            else:
+                raise ValidationError("유효하지 않은 사용자 유형입니다.")
+        return False

--- a/backend/account/serializers.py
+++ b/backend/account/serializers.py
@@ -6,13 +6,6 @@ from .models import User, Teacher, Student
 # serializers.py
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 
-class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
-    @classmethod
-    def get_token(cls, user):
-        token = super().get_token(user)
-        token['uid'] = str(user.uid)
-        return token
-
 class UserSerializer(serializers.ModelSerializer):
     email = serializers.EmailField(required = True, validators=[UniqueValidator(queryset=User.objects.all())])
     name = serializers.CharField(required = True)

--- a/backend/account/tests/test_profile.py
+++ b/backend/account/tests/test_profile.py
@@ -8,47 +8,48 @@ class ProfileTestCase(APITestCase):
         # 테스트용 유저 생성
         self.moke_user = create_moke_user()
         uid = User.objects.get(email=self.moke_user.email).uid
-        self.url = f'/users/{uid}/'
+        self.url_me = f'/users/me/'
+        self.url_user = f'/users/{uid}/'
         self.client.force_authenticate(user=self.moke_user)
 
     def test_get(self):
-        response = self.client.get(self.url)
+        response = self.client.get(self.url_me)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    # 다른 유저를 생성해서 기존 유저의 정보를 수정할 수 있는지 확인하는 함수
-    def test_unauthorized_patch(self):
-        other_user = create_moke_user()
-        self.client.force_authenticate(user=other_user)
-        response = self.client.patch(self.url, {
-            "name": "me"
-        })
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-    # 다른 유저를 생성해서 기존 유저를 삭제할 수 있는지 확인하는 함수
-    def test_unauthorized_delete(self):
-        # 기존 유저에 대한 삭제 권한이 없는 다른 유저 생성
-        other_user = create_moke_user()
-        self.client.force_authenticate(user=other_user)
-        response = self.client.delete(self.url)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
     def test_patch_email(self):
-        response = self.client.patch(self.url, {
+        response = self.client.patch(self.url_me, {
             "email": "logintest@example.com"
         })
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_patch_password(self):
-        response = self.client.patch(self.url, {
+        response = self.client.patch(self.url_me, {
             "password": "logintest"
         })
         updated_user = User.objects.get(email=self.moke_user.email)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertNotEqual("logintest", updated_user.password)
 
+    # 다른 유저를 생성해서 기존 유저의 정보를 수정할 수 있는지 확인하는 함수
+    def test_unauthorized_patch(self):
+        other_user = create_moke_user()
+        self.client.force_authenticate(user=other_user)
+        response = self.client.patch(self.url_user, {
+            "name": "me"
+        })
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    # 다른 유저를 생성해서 기존 유저를 삭제할 수 있는지 확인하는 함수
+    def test_unauthorized_delete(self):
+        # 기존 유저에 대한 삭제 권한이 없는 다른 유저 생성
+        other_user = create_moke_user()
+        self.client.force_authenticate(user=other_user)
+        response = self.client.delete(self.url_user)
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
     def test_patch_other_fields(self):
         if hasattr(self.moke_user, 'school'):
-            response = self.client.patch(self.url, {
+            response = self.client.patch(self.url_me, {
                 "name": "logintest",
                 "school": "동강고",
                 "grade": "고2",
@@ -56,7 +57,7 @@ class ProfileTestCase(APITestCase):
             self.assertEqual("동강고", response.data['school'])
             self.assertEqual("고2", response.data['grade'])
         elif hasattr(self.moke_user, 'institution'):
-            response = self.client.patch(self.url, {
+            response = self.client.patch(self.url_me, {
                 "name": "logintest",
                 "institution": "서강학원",
                 "subject": "영어",

--- a/backend/account/urls.py
+++ b/backend/account/urls.py
@@ -1,14 +1,14 @@
 from django.urls import path
-from .views import RegisterView, UserView
-from .views import CustomTokenObtainPairView
+from .views import RegisterView, UserView, ProfileView
 from rest_framework_simplejwt.views import (
     TokenObtainPairView,
     TokenRefreshView,
 )
 
 urlpatterns = [
-    path('token/', CustomTokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('register/', RegisterView.as_view()),
+    path('me/', ProfileView.as_view()),
     path('<str:pk>/', UserView.as_view()),
 ]


### PR DESCRIPTION
클라이언트에서 uid를 관리하는 방식보다 /users/me/ url을 활용하여 자신의 프로필에 접근할 수 있게 만드는 방식이 더 나을 것 같아 수정하였습니다.